### PR TITLE
Implement dispose method in reporting and task provider interfaces

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -9,6 +9,7 @@ if __name__ == '__main__':
     service = container.container.telegramReportingService()
     service.listenForEvents()
     print("Exiting the program")
-    _exit(0) #TODO: fix hanging threads and remove this line
+    service.dispose()
+    exit(0)
     
     

--- a/backend/src/Interfaces/IReportingService.py
+++ b/backend/src/Interfaces/IReportingService.py
@@ -5,3 +5,7 @@ class IReportingService(ABC):
     @abstractmethod
     def listenForEvents(self):
         pass
+
+    @abstractmethod
+    def dispose(self):
+        pass

--- a/backend/src/Interfaces/ITaskProvider.py
+++ b/backend/src/Interfaces/ITaskProvider.py
@@ -40,3 +40,7 @@ class ITaskProvider(ABC):
     @abstractmethod
     def importTasks(self, selectedFormat : str):
         pass
+
+    @abstractmethod
+    def dispose(self):
+        pass

--- a/backend/src/ObsidianTaskProvider.py
+++ b/backend/src/ObsidianTaskProvider.py
@@ -20,7 +20,7 @@ class ObsidianTaskProvider(ITaskProvider):
         self.lastTaskList : List[ITaskModel] = []
         self.onTaskListUpdatedCallbacks : list[callable] = []
 
-    def __del__(self):
+    def dispose(self):
         self.serviceRunning = False
         self.service.join()
 

--- a/backend/src/TaskProvider.py
+++ b/backend/src/TaskProvider.py
@@ -15,6 +15,9 @@ class TaskProvider(ITaskProvider):
         self.dict_task_list = self.taskJsonProvider.getJson()
         self.taskJsonProvider.onTaskListUpdatedCallbacks = []
 
+    def dispose(self):
+        pass
+
     def getTaskList(self) -> List[ITaskModel]:
         task_list = []
         index = 0

--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -44,6 +44,12 @@ class TelegramReportingService(IReportingService):
         self._lock = threading.Lock()
         pass
 
+    def dispose(self):
+        self.run = False
+        self.bot.shutdown()
+        self.taskProvider.dispose()
+        pass
+
     def onTaskListUpdated(self):
         with self._lock:
             self._updateFlag = True


### PR DESCRIPTION
Add a `dispose` method to the reporting and task provider interfaces to improve exit handling in the backend. Update the backend to call the `dispose` method before exiting, ensuring proper resource cleanup.