### PR TITLE
Fix bug in pagination logic

### DIFF
--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -542,7 +542,8 @@ class TelegramReportingService(IReportingService):
 
         taskListString = "\n".join(subTaskListDescriptions)
         if interactive:
-            taskListString += "\n\nPage " + str(self._taskListPage + 1) + " of " + str(len(self._lastTaskList) // self._tasksPerPage + 1) + "\n"
+            totalPages = (len(self._lastTaskList) + self._tasksPerPage - 1) // self._tasksPerPage
+            taskListString += "\n\nPage " + str(self._taskListPage + 1) + " of " + str(totalPages) + "\n"
             taskListString += "/next - Next page\n/previous - Previous page"
             taskListString += "\n\nselected /heuristic : " + self._heuristicList[self._selectedHeuristicIndex][0]
             taskListString += "\nselected /filter : " + self._filterList[self._selectedFilterIndex][1].getDescription()

--- a/backend/tests/test_TelegramReportingService.py
+++ b/backend/tests/test_TelegramReportingService.py
@@ -55,5 +55,17 @@ class TelegramReportingServiceTests(unittest.TestCase):
         # Assert
         self.assertFalse(self.reportingService.run)
 
+    def test_sendTaskList_DoesNotShowExtraPage_WhenTasksEqualTasksPerPage(self):
+        # Arrange
+        self.reportingService._lastTaskList = ['Task 1', 'Task 2', 'Task 3', 'Task 4', 'Task 5']
+        self.reportingService._tasksPerPage = 5
+
+        # Act
+        self.reportingService._taskListPage = 0
+        self.reportingService.sendTaskList()
+
+        # Assert
+        self.bot.sendMessage.assert_called_with(chat_id=self.chatId, text="Task 1\nTask 2\nTask 3\nTask 4\nTask 5\n\nPage 1 of 1\n/next - Next page\n/previous - Previous page\n\nselected /heuristic : \nselected /filter : ")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adjust the pagination logic in `TelegramReportingService.py` to handle the case where the number of tasks is exactly equal to `_tasksPerPage`.

* Modify the `sendTaskList` method to calculate the total number of pages correctly when the number of tasks is exactly equal to `_tasksPerPage`.
* Add a test case in `test_TelegramReportingService.py` to verify that the `sendTaskList` method does not show an extra page when the number of tasks is exactly equal to `_tasksPerPage`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ElrikPiro/advanced-task-manager/pull/26?shareId=7463390b-5966-4109-bdfd-f93a02445eb3).