### PR TITLE
Use TimeAmount to show the TotalCost value to the user

### DIFF
--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -539,7 +539,7 @@ class TelegramReportingService(IReportingService):
         taskDueDate : TimePoint = TimePoint(datetime.datetime.fromtimestamp(task.getDue() / 1e3))
         taskRemainingCost : TimeAmount = TimeAmount(max(task.getTotalCost(), 0))
         taskEffortInvested = max(task.getInvestedEffort(), 0)
-        taskTotalCost = max(task.getTotalCost(), 0)+taskEffortInvested
+        taskTotalCost = TimeAmount(max(task.getTotalCost(), 0)+taskEffortInvested)
         
         taskInformation = f"Task: {taskDescription}\nContext: {taskContext}\nStart Date: {taskStartDate}\nDue Date: {taskDueDate}\nTotal Cost: {taskTotalCost}\nRemaining: {taskRemainingCost}\nSeverity: {taskSeverity}"
         


### PR DESCRIPTION
Update `sendTaskInformation` method to use `TimeAmount` for displaying `TotalCost` value.

* Convert `TotalCost` value to a `TimeAmount` object in the `sendTaskInformation` method.
* Update the task information message to display the `TotalCost` value as a `TimeAmount` string.

