### PR TITLE
Update getDue method to strip time from due date

### DIFF
--- a/backend/src/taskmodels/TaskModel.py
+++ b/backend/src/taskmodels/TaskModel.py
@@ -26,7 +26,7 @@ class TaskModel(ITaskModel):
         return TimePoint(datetime.datetime.fromtimestamp(self._start / 1e3))
 
     def getDue(self) -> TimePoint:
-        return TimePoint(datetime.datetime.fromtimestamp(self._due / 1e3))
+        return TimePoint(datetime.datetime.fromtimestamp(self._due / 1e3)).strip_time()
 
     def getSeverity(self) -> float:
         return self._severity


### PR DESCRIPTION
Modify the `getDue` method in `TaskModel` to return a due date without the time component.

Closes #45