### PR TITLE
Refactor task saving logic and improve configuration handling

### DIFF
--- a/backend/src/containers/TelegramReportingServiceContainer.py
+++ b/backend/src/containers/TelegramReportingServiceContainer.py
@@ -28,7 +28,7 @@ class TelegramReportingServiceContainer():
     # then it will try to get it from the json configuration file
     def tryGetConfig(self, key: str, required: bool = False, default: str = None) -> str:
         self.config.query.from_env(key, as_=str, required=False, default=None)
-        value = self.config.query()
+        value = None if self.config.query() == "None" else self.config.query()
         if value is None:
             value = self.config.jsonConfig[key]()
         if value is None and required:


### PR DESCRIPTION
This pull request includes several changes to the `TelegramReportingServiceContainer` and `ObsidianTaskProvider` classes, as well as updates to the corresponding test suite. The main focus is on improving the handling of task data and ensuring proper configuration retrieval.

Improvements to task handling:

* [`backend/src/taskproviders/ObsidianTaskProvider.py`](diffhunk://#diff-2f2dcbc7d47e45952a4309644fb489fb14ebf9a360155b5ff33ebcc85d7efcd6L62-R62): Refactored the `saveTask` method by introducing a new `_getTaskLine` method to generate the task line string, and added logic to handle tasks without file data and to clean task lines before saving. [[1]](diffhunk://#diff-2f2dcbc7d47e45952a4309644fb489fb14ebf9a360155b5ff33ebcc85d7efcd6L62-R62) [[2]](diffhunk://#diff-2f2dcbc7d47e45952a4309644fb489fb14ebf9a360155b5ff33ebcc85d7efcd6L73-R76) [[3]](diffhunk://#diff-2f2dcbc7d47e45952a4309644fb489fb14ebf9a360155b5ff33ebcc85d7efcd6L83-R95)

Configuration retrieval enhancement:

* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6L31-R31): Improved the `tryGetConfig` method to handle cases where the configuration query returns "None" as a string, ensuring it is treated as a `None` value.

Test suite updates:

* [`backend/tests/ObsidianTaskProvider_test.py`](diffhunk://#diff-fe3a666ac267334f7a3a786ce27578d0da5bcbbde782c3008ade67fbc3261ed0L4-R9): Added new test cases to verify the behavior of the `saveTask` method when tasks have no file data or when tasks already have file data. Updated imports to include necessary classes and modules. [[1]](diffhunk://#diff-fe3a666ac267334f7a3a786ce27578d0da5bcbbde782c3008ade67fbc3261ed0L4-R9) [[2]](diffhunk://#diff-fe3a666ac267334f7a3a786ce27578d0da5bcbbde782c3008ade67fbc3261ed0R36-R93)

Fixes #53 