### PR TITLE
Add default configuration and enhance error handling for TelegramReportingServiceContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ import.dat
 backend/build/
 backend/dist/
 config.json
+.coverage


### PR DESCRIPTION
This pull request introduces several key changes to the `TelegramReportingServiceContainer` class to enhance configuration management and user interaction. The most significant changes include the addition of a method to create a default configuration, handling configuration file errors, and updating the configuration logic.

Configuration management improvements:

* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R42-R143): Added a new method `createDefaultConfig` to create a default configuration file with user input for various settings, such as categories, app mode, JSON path, Telegram bot token, Telegram chat ID, appdata directory, and Obsidian vault path.
* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R42-R143): Modified the constructor to handle errors when reading the `config.json` file. If an error occurs, it creates a default configuration using the new method.

Codebase simplification:

* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R42-R143): Updated the logic for determining `telegramMode` and `obsidianMode` based on the `APP_MODE` configuration.
* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R42-R143): Changed the `tryGetConfig` method calls to use the `required` parameter instead of positional arguments for clarity.

Dependency management:

* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R1-R2): Added imports for `json` and `os` modules to support the new configuration management functionality.

Closes #42 