### PR TITLE
#65 : Removes ignoreNextUpdate patch in TelegramReportingService

### DIFF
--- a/backend/src/ProjectManager.py
+++ b/backend/src/ProjectManager.py
@@ -42,7 +42,7 @@ class ObsidianProjectManager(IProjectManager):
         else:
             return self._get_help()
 
-    def _get_help(self, messageArgs: List[str]) -> str:
+    def _get_help(self, messageArgs: List[str] = []) -> str:
         """
         Get the help message for the project manager.
 

--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -40,8 +40,6 @@ class TelegramReportingService(IReportingService):
         self._lastError = "Event loop initialized"
         self._lock = threading.Lock()
 
-        self._ignoreNextUpdate = False
-
         self._categories = categories
         pass
 
@@ -104,9 +102,6 @@ class TelegramReportingService(IReportingService):
             if len(filteredList) != 0:
                 nextTask = f"\n\n/task_1: {filteredList[0].getDescription()}"
             self._taskListManager.reset_pagination()
-            if self._ignoreNextUpdate:
-                self._ignoreNextUpdate = False
-                return
             await self.bot.sendMessage(chat_id=self.chatId, text="Task /list updated" + nextTask)
 
     async def runEventLoop(self):
@@ -193,7 +188,6 @@ class TelegramReportingService(IReportingService):
             task = selected_task
             task.setStatus("x")
             self.taskProvider.saveTask(task)
-            self._ignoreNextUpdate = True
             if expectAnswer:
                 await self.sendTaskList()
         else:
@@ -209,7 +203,6 @@ class TelegramReportingService(IReportingService):
                 params[1] = "me"
             await self.processSetParam(task, params[0], " ".join(params[1:]) if len(params) > 2 else params[1])
             self.taskProvider.saveTask(task)
-            self._ignoreNextUpdate = True
             if expectAnswer:
                 await self.sendTaskInformation(task)
         else:
@@ -230,7 +223,6 @@ class TelegramReportingService(IReportingService):
                 selected_task = self._taskListManager.selected_task
 
             self.taskProvider.saveTask(selected_task)
-            self._ignoreNextUpdate = True
             self._taskListManager.add_task(selected_task)
             if expectAnswer:
                 await self.sendTaskInformation(selected_task)

--- a/backend/tests/TelegramReportingService_test.py
+++ b/backend/tests/TelegramReportingService_test.py
@@ -124,6 +124,264 @@ class TestTelegramReportingService(unittest.TestCase):
         # Assert
         mock_helpCommand.assert_called_once_with("/unknown_command", True)
 
+    async def test_checkFilteredListChanges_no_changes(self):
+        # Arrange
+        self.telegramReportingService.chatId = 123456789
+        self.telegramReportingService.hasFilteredListChanged = MagicMock(return_value=False)
+
+        # Act
+        await self.telegramReportingService.checkFilteredListChanges()
+
+        # Assert
+        self.bot.sendMessage.assert_not_called()
+
+    async def test_checkFilteredListChanges_with_empty_list(self):
+        # Arrange
+        self.telegramReportingService.chatId = 123456789
+        self.telegramReportingService.hasFilteredListChanged = MagicMock(return_value=True)
+        self.task_list_manager.filtered_task_list = []
+        self.task_list_manager.reset_pagination = MagicMock()
+
+        # Act
+        await self.telegramReportingService.checkFilteredListChanges()
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="Task /list updated"
+        )
+        self.task_list_manager.reset_pagination.assert_called_once()
+
+    async def test_checkFilteredListChanges_with_tasks(self):
+        # Arrange
+        self.telegramReportingService.chatId = 123456789
+        self.telegramReportingService.hasFilteredListChanged = MagicMock(return_value=True)
+        mockTask = MagicMock()
+        mockTask.getDescription.return_value = "Test Task"
+        self.task_list_manager.filtered_task_list = [mockTask]
+        self.task_list_manager.reset_pagination = MagicMock()
+
+        # Act
+        await self.telegramReportingService.checkFilteredListChanges()
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="Task /list updated\n\n/task_1: Test Task"
+        )
+        self.task_list_manager.reset_pagination.assert_called_once()
+
+    async def test_checkFilteredListChanges_with_zero_chatId(self):
+        # Arrange
+        self.telegramReportingService.chatId = 0
+        self.telegramReportingService.hasFilteredListChanged = MagicMock()
+
+        # Act
+        await self.telegramReportingService.checkFilteredListChanges()
+
+        # Assert
+        self.telegramReportingService.hasFilteredListChanged.assert_not_called()
+        self.bot.sendMessage.assert_not_called()
+
+    async def test_doneCommand_with_selected_task(self):
+        # Arrange
+        mockTask = MagicMock()
+        mockTask.setStatus = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.sendTaskList = AsyncMock()
+
+        # Act
+        await self.telegramReportingService.doneCommand()
+
+        # Assert
+        mockTask.setStatus.assert_called_once_with("x")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskList.assert_called_once()
+
+    async def test_doneCommand_without_selected_task(self):
+        # Arrange
+        self.task_list_manager.selected_task = None
+
+        # Act
+        await self.telegramReportingService.doneCommand()
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="no task selected."
+        )
+
+    async def test_doneCommand_no_expectAnswer(self):
+        # Arrange
+        mockTask = MagicMock()
+        mockTask.setStatus = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.sendTaskList = AsyncMock()
+
+        # Act
+        await self.telegramReportingService.doneCommand(expectAnswer=False)
+
+        # Assert
+        mockTask.setStatus.assert_called_once_with("x")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskList.assert_not_called()
+
+    @patch.object(TelegramReportingService, 'processSetParam')
+    async def test_setCommand_with_selected_task(self, mock_processSetParam):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/set description New Task Description"
+        mock_processSetParam.return_value = None
+
+        # Act
+        await self.telegramReportingService.setCommand(messageText)
+
+        # Assert
+        mock_processSetParam.assert_called_once_with(mockTask, "description", "New Task Description")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_called_once_with(mockTask)
+
+    @patch.object(TelegramReportingService, 'processSetParam')
+    async def test_setCommand_with_multiple_params(self, mock_processSetParam):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/set context @test Project"
+        mock_processSetParam.return_value = None
+
+        # Act
+        await self.telegramReportingService.setCommand(messageText)
+
+        # Assert
+        mock_processSetParam.assert_called_once_with(mockTask, "context", "@test Project")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_called_once_with(mockTask)
+
+    @patch.object(TelegramReportingService, 'processSetParam')
+    async def test_setCommand_insufficient_params(self, mock_processSetParam):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        messageText = "/set"
+        mock_processSetParam.return_value = None
+
+        # Act
+        await self.telegramReportingService.setCommand(messageText)
+
+        # Assert
+        mock_processSetParam.assert_called_once_with(mockTask, "help", "me")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+
+    async def test_setCommand_no_selected_task(self):
+        # Arrange
+        self.task_list_manager.selected_task = None
+        messageText = "/set description New Task Description"
+
+        # Act
+        await self.telegramReportingService.setCommand(messageText)
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="no task selected."
+        )
+
+    @patch.object(TelegramReportingService, 'processSetParam')
+    async def test_setCommand_no_expectAnswer(self, mock_processSetParam):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/set severity 5"
+        mock_processSetParam.return_value = None
+
+        # Act
+        await self.telegramReportingService.setCommand(messageText, expectAnswer=False)
+
+        # Assert
+        mock_processSetParam.assert_called_once_with(mockTask, "severity", "5")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_not_called()
+
+    async def test_newCommand_with_description(self):
+        # Arrange
+        mockTask = MagicMock()
+        self.taskProvider.createDefaultTask = MagicMock(return_value=mockTask)
+        self.taskProvider.saveTask = MagicMock()
+        self.task_list_manager.add_task = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/new Test task description"
+
+        # Act
+        await self.telegramReportingService.newCommand(messageText)
+
+        # Assert
+        self.taskProvider.createDefaultTask.assert_called_once_with("Test task description")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.task_list_manager.add_task.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_called_once_with(mockTask)
+
+    async def test_newCommand_with_extended_params(self):
+        # Arrange
+        mockTask = MagicMock()
+        mockTask.setContext = MagicMock()
+        mockTask.setTotalCost = MagicMock()
+        self.taskProvider.createDefaultTask = MagicMock(return_value=mockTask)
+        self.taskProvider.saveTask = MagicMock()
+        self.task_list_manager.add_task = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/new Test task description;@test context;2p"
+
+        # Act
+        await self.telegramReportingService.newCommand(messageText)
+
+        # Assert
+        self.taskProvider.createDefaultTask.assert_called_once_with("Test task description")
+        mockTask.setContext.assert_called_once_with("@test context")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.task_list_manager.add_task.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_called_once_with(mockTask)
+
+    async def test_newCommand_no_description(self):
+        # Arrange
+        messageText = "/new"
+
+        # Act
+        await self.telegramReportingService.newCommand(messageText)
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="no description provided."
+        )
+
+    async def test_newCommand_no_expectAnswer(self):
+        # Arrange
+        mockTask = MagicMock()
+        self.taskProvider.createDefaultTask = MagicMock(return_value=mockTask)
+        self.taskProvider.saveTask = MagicMock()
+        self.task_list_manager.add_task = MagicMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/new Test task description"
+
+        # Act
+        await self.telegramReportingService.newCommand(messageText, expectAnswer=False)
+
+        # Assert
+        self.taskProvider.createDefaultTask.assert_called_once_with("Test task description")
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.task_list_manager.add_task.assert_called_once_with(mockTask)
+        self.telegramReportingService.sendTaskInformation.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request includes changes to the `backend/src/ProjectManager.py` and `backend/src/TelegramReportingService.py` files. The most important changes involve the removal of an unnecessary flag and the adjustment of method parameters to provide default values.

Changes to `backend/src/ProjectManager.py`:

* Modified the `_get_help` method to provide a default value for the `messageArgs` parameter.

Changes to `backend/src/TelegramReportingService.py`:

* Removed the `_ignoreNextUpdate` flag and its associated logic from multiple methods, simplifying the codebase. [[1]](diffhunk://#diff-cdf29ac685e7bd30b517bdcfc3819200af36a52732ddf1ea86b7c9f7fe543059L43-L44) [[2]](diffhunk://#diff-cdf29ac685e7bd30b517bdcfc3819200af36a52732ddf1ea86b7c9f7fe543059L107-L109) [[3]](diffhunk://#diff-cdf29ac685e7bd30b517bdcfc3819200af36a52732ddf1ea86b7c9f7fe543059L196) [[4]](diffhunk://#diff-cdf29ac685e7bd30b517bdcfc3819200af36a52732ddf1ea86b7c9f7fe543059L212) [[5]](diffhunk://#diff-cdf29ac685e7bd30b517bdcfc3819200af36a52732ddf1ea86b7c9f7fe543059L233)

Fixes #65