### PR TITLE
Add work done logging to statistics service

### DIFF
--- a/backend/src/Interfaces/IStatisticsService.py
+++ b/backend/src/Interfaces/IStatisticsService.py
@@ -8,7 +8,7 @@ from ..wrappers.TimeManagement import TimePoint, TimeAmount
 class IStatisticsService(ABC):
 
     @abstractmethod
-    def doWork(self, date: datetime.date, work_units: float, task: ITaskModel):
+    def doWork(self, date: datetime.date, work_units: TimeAmount, task: ITaskModel):
         pass
 
     @abstractmethod

--- a/backend/src/Interfaces/IStatisticsService.py
+++ b/backend/src/Interfaces/IStatisticsService.py
@@ -22,3 +22,7 @@ class IStatisticsService(ABC):
     @abstractmethod
     def initialize(self):
         pass
+
+    @abstractmethod
+    def getWorkDoneLog(self) -> list:
+        pass

--- a/backend/src/Interfaces/IStatisticsService.py
+++ b/backend/src/Interfaces/IStatisticsService.py
@@ -8,7 +8,7 @@ from ..wrappers.TimeManagement import TimePoint, TimeAmount
 class IStatisticsService(ABC):
 
     @abstractmethod
-    def doWork(self, date: datetime.date, work_units: float):
+    def doWork(self, date: datetime.date, work_units: float, task: ITaskModel):
         pass
 
     @abstractmethod

--- a/backend/src/Interfaces/IStatisticsService.py
+++ b/backend/src/Interfaces/IStatisticsService.py
@@ -9,6 +9,14 @@ class IStatisticsService(ABC):
 
     @abstractmethod
     def doWork(self, date: datetime.date, work_units: TimeAmount, task: ITaskModel):
+        """
+        Records work done on a task on a given date.
+
+        Params:
+            date: The date on which the work was done.
+            work_units: The amount of work done.
+            task: The task on which the work was done.
+        """
         pass
 
     @abstractmethod
@@ -25,4 +33,14 @@ class IStatisticsService(ABC):
 
     @abstractmethod
     def getWorkDoneLog(self) -> list:
+        """
+        Returns a list of dictionaries representing the work done log.
+
+        Returns:
+            A list of dictionaries representing the work done log.
+            Fields are the following:
+                - timestamp: The timestamp of the work done.
+                - work_units: The amount of work done.
+                - task: The task on which the work was done.
+        """
         pass

--- a/backend/src/StatisticsService.py
+++ b/backend/src/StatisticsService.py
@@ -29,7 +29,7 @@ class StatisticsService(IStatisticsService):
         self.workDone[date.isoformat()] = self.workDone.get(date.isoformat(), 0.0) + work_units
         self.workDone["log"] = self.workDone.get("log", [])
         self.workDone["log"].append({"timestamp": TimePoint.now().as_int(), "work_units": work_units, "task": task.getDescription()})
-        self.workDone["log"] = [entry for entry in self.workDone["log"] if TimePoint.now().as_int() - entry["timestamp"] < 86400]
+        self.workDone["log"] = [entry for entry in self.workDone["log"] if TimePoint.now().as_int() - entry["timestamp"] < 86400000]
 
         TimeAmount(f"{work_units}p")
         print(f"Work done on {TimePoint.now()}: {work_units}p on {task.getDescription()}")
@@ -64,3 +64,6 @@ class StatisticsService(IStatisticsService):
 
         retval = [workload, remainingEffort, maxHeuristic, HeuristicName, offender, offenderMax]
         return retval
+
+    def getWorkDoneLog(self) -> list:
+        return self.workDone["log"]

--- a/backend/src/StatisticsService.py
+++ b/backend/src/StatisticsService.py
@@ -25,14 +25,14 @@ class StatisticsService(IStatisticsService):
             print(f"{e.__class__.__name__}: {e}")
             print("Initializing StatisticsService with empty data.")
 
-    def doWork(self, date: datetime.date, work_units: float, task: ITaskModel):
-        self.workDone[date.isoformat()] = self.workDone.get(date.isoformat(), 0.0) + work_units
+    def doWork(self, date: datetime.date, work_units: TimeAmount, task: ITaskModel):
+        work_units_pomodoros: float = work_units.as_pomodoros()
+        self.workDone[date.isoformat()] = self.workDone.get(date.isoformat(), 0.0) + work_units_pomodoros
         self.workDone["log"] = self.workDone.get("log", [])
-        self.workDone["log"].append({"timestamp": TimePoint.now().as_int(), "work_units": work_units, "task": task.getDescription()})
+        self.workDone["log"].append({"timestamp": TimePoint.now().as_int(), "work_units": work_units_pomodoros, "task": task.getDescription()})
         self.workDone["log"] = [entry for entry in self.workDone["log"] if TimePoint.now().as_int() - entry["timestamp"] < 86400000]
 
-        TimeAmount(f"{work_units}p")
-        print(f"Work done on {TimePoint.now()}: {work_units}p on {task.getDescription()}")
+        print(f"Work done on {TimePoint.now()}: {work_units} on {task.getDescription()}")
         self.fileBroker.writeFileContentJson(FileRegistry.STATISTICS_JSON, self.workDone)
 
     def getWorkDone(self, date: TimePoint) -> TimeAmount:

--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -455,7 +455,7 @@ class TelegramReportingService(IReportingService):
             await self.processSetParam(task, "effort_invested", f"{str(work_units.as_pomodoros())}p")
             self.taskProvider.saveTask(task)
             date = datetime.datetime.now().date()
-            self.statiticsProvider.doWork(date, work_units.as_pomodoros(), task)
+            self.statiticsProvider.doWork(date, work_units, task)
             if expectAnswer:
                 await self.sendTaskInformation(task)
         else:

--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -639,7 +639,7 @@ class TelegramReportingService(IReportingService):
                 currentTimePoint = currentTimePoint.today()
             elif value == "tomorrow":
                 currentTimePoint = currentTimePoint.tomorrow()
-            elif value.find(":") > 0:
+            elif value.find(":") > 0 and value.find("T") < 0:
                 currentTimePoint = currentTimePoint.strip_time() + TimeAmount(value)
             else:
                 currentTimePoint = currentTimePoint + TimeAmount(value)

--- a/backend/src/TelegramReportingService.py
+++ b/backend/src/TelegramReportingService.py
@@ -455,7 +455,7 @@ class TelegramReportingService(IReportingService):
             await self.processSetParam(task, "effort_invested", f"{str(work_units.as_pomodoros())}p")
             self.taskProvider.saveTask(task)
             date = datetime.datetime.now().date()
-            self.statiticsProvider.doWork(date, work_units.as_pomodoros())
+            self.statiticsProvider.doWork(date, work_units.as_pomodoros(), task)
             if expectAnswer:
                 await self.sendTaskInformation(task)
         else:

--- a/backend/src/TelegramTaskListManager.py
+++ b/backend/src/TelegramTaskListManager.py
@@ -177,7 +177,8 @@ class TelegramTaskListManager(ITaskListManager):
             task = entry["task"]
             work_units = entry["work_units"]
             timestamp = TimePoint.from_int(entry["timestamp"])
-            statsMessage += f"`{timestamp}: {work_units}p on {task}`\n"
+            timeAmount = TimeAmount(f"{work_units}p")
+            statsMessage += f"`{timestamp}: {timeAmount} on {task}`\n"
 
         statsMessage += "/list - return back to the task list"
         return statsMessage

--- a/backend/src/TelegramTaskListManager.py
+++ b/backend/src/TelegramTaskListManager.py
@@ -170,6 +170,15 @@ class TelegramTaskListManager(ITaskListManager):
         statsMessage += f"    `max Offender: '{offender}' with {offenderMax} per day`\n"
         statsMessage += f"`total remaining effort: {remEffort}`\n"
         statsMessage += f"`max {heuristicName}: {heuristicValue}`\n\n"
+
+        log = self.__statistics_service.getWorkDoneLog()
+        statsMessage += "Work done log:\n"
+        for entry in log:
+            task = entry["task"]
+            work_units = entry["work_units"]
+            timestamp = TimePoint.from_int(entry["timestamp"])
+            statsMessage += f"`{timestamp}: {work_units}p on {task}`\n"
+
         statsMessage += "/list - return back to the task list"
         return statsMessage
 

--- a/backend/src/wrappers/TimeManagement.py
+++ b/backend/src/wrappers/TimeManagement.py
@@ -96,6 +96,10 @@ class TimePoint:
         except ValueError:
             return TimePoint(datetime.datetime.strptime(string, "%Y-%m-%d"))
 
+    @staticmethod
+    def from_int(value: int):
+        return TimePoint(datetime.datetime.fromtimestamp(value / 1e3))
+
     def as_int(self):
         return int(self.datetime_representation.timestamp() * 1e3)
 

--- a/backend/tests/StatisticsService_test.py
+++ b/backend/tests/StatisticsService_test.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import Mock, patch
+import datetime
+
+from src.StatisticsService import StatisticsService
+from src.Interfaces.IFileBroker import FileRegistry
+from src.wrappers.TimeManagement import TimeAmount
+
+
+class TestStatisticsService(unittest.TestCase):
+    def setUp(self):
+        # Create mock objects
+        self.mock_file_broker = Mock()
+        self.mock_workload_filter = Mock()
+        self.mock_remaining_effort_heuristic = Mock()
+        self.mock_main_heuristic = Mock()
+        self.mock_task = Mock()
+
+        # Configure mock task
+        self.mock_task.getDescription.return_value = "Test Task"
+        self.mock_task.getTotalCost.return_value = TimeAmount("4p")
+        self.mock_task.calculateRemainingTime.return_value = TimeAmount("2d")
+
+        # Create the service with mocks
+        self.service = StatisticsService(
+            self.mock_file_broker,
+            self.mock_workload_filter,
+            self.mock_remaining_effort_heuristic,
+            self.mock_main_heuristic
+        )
+
+    def test_do_work(self):
+        # Arrange
+        test_date = datetime.date(2023, 1, 1)
+        work_units = 2.5
+
+        # Act
+        with patch('src.wrappers.TimeManagement.TimePoint.now') as mock_now:
+            mock_now.return_value.as_int.return_value = 1672531200000  # 2023-01-01
+            mock_now.return_value.__str__.return_value = "2023-01-01"
+            self.service.doWork(test_date, work_units, self.mock_task)
+
+        # Assert
+        self.assertEqual(self.service.workDone[test_date.isoformat()], work_units)
+        self.mock_file_broker.writeFileContentJson.assert_called_once_with(
+            FileRegistry.STATISTICS_JSON, self.service.workDone
+        )
+
+    def test_do_work_accumulates_work(self):
+        # Arrange
+        test_date = datetime.date(2023, 1, 1)
+        initial_work = 1.5
+        additional_work = 2.0
+        self.service.workDone = {test_date.isoformat(): initial_work}
+
+        # Act
+        with patch('src.wrappers.TimeManagement.TimePoint.now') as mock_now:
+            mock_now.return_value.as_int.return_value = 1672531200000
+            mock_now.return_value.__str__.return_value = "2023-01-01"
+            self.service.doWork(test_date, additional_work, self.mock_task)
+
+        # Assert
+        self.assertEqual(self.service.workDone[test_date.isoformat()], initial_work + additional_work)
+
+    def test_get_work_done_log(self):
+        # Arrange
+        log_entries = [
+            {"timestamp": 1672531200000, "work_units": 2.0, "task": "Task 1"},
+            {"timestamp": 1672534800000, "work_units": 1.5, "task": "Task 2"}
+        ]
+        self.service.workDone = {"log": log_entries}
+
+        # Act
+        result = self.service.getWorkDoneLog()
+
+        # Assert
+        self.assertEqual(result, log_entries)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/StatisticsService_test.py
+++ b/backend/tests/StatisticsService_test.py
@@ -32,7 +32,7 @@ class TestStatisticsService(unittest.TestCase):
     def test_do_work(self):
         # Arrange
         test_date = datetime.date(2023, 1, 1)
-        work_units = 2.5
+        work_units = TimeAmount("2.5p")
 
         # Act
         with patch('src.wrappers.TimeManagement.TimePoint.now') as mock_now:
@@ -41,7 +41,7 @@ class TestStatisticsService(unittest.TestCase):
             self.service.doWork(test_date, work_units, self.mock_task)
 
         # Assert
-        self.assertEqual(self.service.workDone[test_date.isoformat()], work_units)
+        self.assertEqual(self.service.workDone[test_date.isoformat()], work_units.as_pomodoros())
         self.mock_file_broker.writeFileContentJson.assert_called_once_with(
             FileRegistry.STATISTICS_JSON, self.service.workDone
         )
@@ -49,9 +49,9 @@ class TestStatisticsService(unittest.TestCase):
     def test_do_work_accumulates_work(self):
         # Arrange
         test_date = datetime.date(2023, 1, 1)
-        initial_work = 1.5
-        additional_work = 2.0
-        self.service.workDone = {test_date.isoformat(): initial_work}
+        initial_work = TimeAmount("1.6p")
+        additional_work = TimeAmount("2.0p")
+        self.service.workDone = {test_date.isoformat(): initial_work.as_pomodoros()}
 
         # Act
         with patch('src.wrappers.TimeManagement.TimePoint.now') as mock_now:
@@ -60,7 +60,7 @@ class TestStatisticsService(unittest.TestCase):
             self.service.doWork(test_date, additional_work, self.mock_task)
 
         # Assert
-        self.assertEqual(self.service.workDone[test_date.isoformat()], initial_work + additional_work)
+        self.assertEqual(self.service.workDone[test_date.isoformat()], initial_work.as_pomodoros() + additional_work.as_pomodoros())
 
     def test_get_work_done_log(self):
         # Arrange

--- a/backend/tests/TelegramReportingService_test.py
+++ b/backend/tests/TelegramReportingService_test.py
@@ -460,6 +460,73 @@ class TestTelegramReportingService(unittest.TestCase):
         # Assert
         self.assertEqual(result.datetime_representation, expected)
 
+    def test_workCommand_with_selected_task(self):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.processSetParam = AsyncMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/work 2p"
+
+        # Act
+        asyncio.run(self.telegramReportingService.workCommand(messageText))
+
+        # Assert
+        self.telegramReportingService.processSetParam.assert_called_once()
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.statisticsProvider.doWork.assert_called_once()
+        self.telegramReportingService.sendTaskInformation.assert_called_once_with(mockTask)
+
+    def test_workCommand_without_selected_task(self):
+        # Arrange
+        self.task_list_manager.selected_task = None
+        messageText = "/work 2p"
+
+        # Act
+        asyncio.run(self.telegramReportingService.workCommand(messageText))
+
+        # Assert
+        self.bot.sendMessage.assert_called_once_with(
+            chat_id=123456789,
+            text="no task provided."
+        )
+
+    def test_workCommand_with_time_amount(self):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.processSetParam = AsyncMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/work 1h"
+
+        # Act
+        asyncio.run(self.telegramReportingService.workCommand(messageText))
+
+        # Assert
+        # Check that processSetParam is called with the correct effort parameter
+        self.telegramReportingService.processSetParam.assert_called_once()
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.statisticsProvider.doWork.assert_called_once()
+
+    def test_workCommand_no_expectAnswer(self):
+        # Arrange
+        mockTask = MagicMock()
+        self.task_list_manager.selected_task = mockTask
+        self.taskProvider.saveTask = MagicMock()
+        self.telegramReportingService.processSetParam = AsyncMock()
+        self.telegramReportingService.sendTaskInformation = AsyncMock()
+        messageText = "/work 2p"
+
+        # Act
+        asyncio.run(self.telegramReportingService.workCommand(messageText, expectAnswer=False))
+
+        # Assert
+        self.taskProvider.saveTask.assert_called_once_with(mockTask)
+        self.statisticsProvider.doWork.assert_called_once()
+        self.telegramReportingService.sendTaskInformation.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/TelegramTaskListManager_test.py
+++ b/backend/tests/TelegramTaskListManager_test.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest.mock import MagicMock
+from src.TelegramTaskListManager import TelegramTaskListManager
+from src.wrappers.TimeManagement import TimeAmount, TimePoint
+
+
+class TestTelegramTaskListManager(unittest.TestCase):
+
+    def setUp(self):
+        # Create mock task models
+        self.task1 = MagicMock()
+        self.task1.getDescription.return_value = "Task 1"
+        self.task1.getStatus.return_value = ""
+
+        self.task2 = MagicMock()
+        self.task2.getDescription.return_value = "Task 2"
+        self.task2.getStatus.return_value = ""
+
+        self.task_list = [self.task1, self.task2]
+
+        # Create mock statistics service
+        self.statistics_service = MagicMock()
+
+        # Create mock heuristics and filters
+        self.heuristics = [("Priority", MagicMock())]
+        self.filters = [("Active", MagicMock())]
+
+        # Create the task list manager
+        self.task_list_manager = TelegramTaskListManager(
+            self.task_list,
+            self.heuristics,
+            self.filters,
+            self.statistics_service
+        )
+
+    def test_get_list_stats(self):
+        # Arrange
+        # Set up getWorkDone to return different values for different dates
+        work_done_values = {
+            0: TimeAmount("2p"),
+            1: TimeAmount("3p"),
+            2: TimeAmount("1.5p"),
+            3: TimeAmount("0p"),
+            4: TimeAmount("2.5p"),
+            5: TimeAmount("1p"),
+            6: TimeAmount("4p")
+        }
+
+        def mock_get_work_done(date):
+            # Find which day this is by comparing with today
+            today = TimePoint.today()
+            for i in range(7):
+                if (today + TimeAmount(f"-{i}d")).as_int() == date.as_int():
+                    return work_done_values.get(i, TimeAmount("0p"))
+            return TimeAmount("0p")
+
+        self.statistics_service.getWorkDone.side_effect = mock_get_work_done
+
+        # Set up getWorkloadStats to return predefined values
+        workload_stats = (
+            "2.0p",  # workload
+            "10p",   # remaining effort
+            "0.8",   # heuristic value
+            "Urgency",  # heuristic name
+            "Task 1",   # offender
+            "1.5p"      # offenderMax
+        )
+        self.statistics_service.getWorkloadStats.return_value = workload_stats
+
+        # Set up getWorkDoneLog to return a sample log
+        work_done_log = [
+            {"task": "Task 1", "work_units": "2p", "timestamp": TimePoint.now().as_int()},
+            {"task": "Task 2", "work_units": "1p", "timestamp": TimePoint.now().as_int() - 3600}
+        ]
+        self.statistics_service.getWorkDoneLog.return_value = work_done_log
+
+        # Act
+        result = self.task_list_manager.get_list_stats()
+
+        # Assert
+        # Check that the result contains expected parts
+        self.assertIn("Work done in the last 7 days:", result)
+        self.assertIn("|    Date    | Work Done |", result)
+
+        # Check for the average work done (2 + 3 + 1.5 + 0 + 2.5 + 1 + 4) / 7 = 2.0
+        self.assertIn("|   Average  |    2.0    |", result)
+
+        # Check workload statistics section
+        self.assertIn("Workload statistics:", result)
+        self.assertIn("current workload: 2.0p per day", result)
+        self.assertIn("max Offender: 'Task 1' with 1.5p per day", result)
+        self.assertIn("total remaining effort: 10p", result)
+        self.assertIn("max Urgency: 0.8", result)
+
+        # Check work done log section
+        self.assertIn("Work done log:", result)
+        for entry in work_done_log:
+            task = entry["task"]
+            work_units = entry["work_units"]
+            self.assertIn(f"{work_units}p on {task}", result)
+
+        # Check navigation option is present
+        self.assertIn("/list - return back to the task list", result)
+
+        # Verify function calls
+        self.assertEqual(self.statistics_service.getWorkDone.call_count, 7)
+        self.statistics_service.getWorkloadStats.assert_called_once_with(self.task_list)
+        self.statistics_service.getWorkDoneLog.assert_called_once()
+
+    def test_get_list_stats_with_zero_work_done(self):
+        # Arrange
+        # Set up getWorkDone to always return zero
+        self.statistics_service.getWorkDone.return_value = TimeAmount("0p")
+
+        # Set up getWorkloadStats to return predefined values
+        workload_stats = (
+            "0p",    # workload
+            "0p",    # remaining effort
+            "0.0",   # heuristic value
+            "Priority",  # heuristic name
+            "None",  # offender
+            "0p"     # offenderMax
+        )
+        self.statistics_service.getWorkloadStats.return_value = workload_stats
+
+        # Set up empty work log
+        self.statistics_service.getWorkDoneLog.return_value = []
+
+        # Act
+        result = self.task_list_manager.get_list_stats()
+
+        # Assert
+        # Check that the result contains expected parts
+        self.assertIn("Work done in the last 7 days:", result)
+
+        # Check for zero average work done
+        self.assertIn("|   Average  |    0.0    |", result)
+
+        # Check workload statistics section with zeros
+        self.assertIn("current workload: 0p per day", result)
+        self.assertIn("total remaining effort: 0p", result)
+
+        # Check empty work done log section
+        self.assertIn("Work done log:", result)
+
+        # Verify function calls
+        self.assertEqual(self.statistics_service.getWorkDone.call_count, 7)
+        self.statistics_service.getWorkloadStats.assert_called_once()
+        self.statistics_service.getWorkDoneLog.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/TelegramTaskListManager_test.py
+++ b/backend/tests/TelegramTaskListManager_test.py
@@ -69,8 +69,8 @@ class TestTelegramTaskListManager(unittest.TestCase):
 
         # Set up getWorkDoneLog to return a sample log
         work_done_log = [
-            {"task": "Task 1", "work_units": "2p", "timestamp": TimePoint.now().as_int()},
-            {"task": "Task 2", "work_units": "1p", "timestamp": TimePoint.now().as_int() - 3600}
+            {"task": "Task 1", "work_units": "2", "timestamp": TimePoint.now().as_int()},
+            {"task": "Task 2", "work_units": "1", "timestamp": TimePoint.now().as_int() - 3600}
         ]
         self.statistics_service.getWorkDoneLog.return_value = work_done_log
 
@@ -97,7 +97,8 @@ class TestTelegramTaskListManager(unittest.TestCase):
         for entry in work_done_log:
             task = entry["task"]
             work_units = entry["work_units"]
-            self.assertIn(f"{work_units}p on {task}", result)
+            timeAmount = TimeAmount(f"{work_units}p")
+            self.assertIn(f"{timeAmount} on {task}", result)
 
         # Check navigation option is present
         self.assertIn("/list - return back to the task list", result)


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and data tracking of the statistics service. The most important changes include adding a new parameter to the `doWork` method, introducing a method to retrieve the work done log, and updating related classes to utilize these new functionalities.

### Enhancements to `IStatisticsService`:

* Added a `task` parameter to the `doWork` method to track which task the work units are associated with.
* Introduced a new abstract method `getWorkDoneLog` to retrieve the log of work done.

### Updates in `StatisticsService`:

* Modified the `doWork` method to include logging of work done with timestamps and task descriptions.
* Implemented the `getWorkDoneLog` method to return the work done log.

### Changes in related service classes:

* Updated `workCommand` in `TelegramReportingService` to pass the `task` parameter when calling `doWork`.
* Enhanced `get_list_stats` in `TelegramTaskListManager` to include the work done log in the statistics message.

### Utility updates:

* Added a `from_int` method to `TimePoint` class to convert timestamps back to `TimePoint` objects.

Closes #15