### PR TITLE
Add user-configurable policies for task handling

### DIFF
--- a/backend/src/containers/TelegramReportingServiceContainer.py
+++ b/backend/src/containers/TelegramReportingServiceContainer.py
@@ -193,14 +193,15 @@ class TelegramReportingServiceContainer():
         vaultPath = self.tryGetConfig("OBSIDIAN_VAULT_PATH", obsidianMode, default="NULL_VAULT_PATH")
 
         dedicationTime = TimeAmount(self.tryGetConfig("DEDICATION_TIME", required=False, default="2p"))
+        categoriesConfigOption = self.config.jsonConfig.categories()
+        self.container.categories = list[dict](categoriesConfigOption)
+
         taskDiscoveryPolicies = {
             "context_missing_policy": self.tryGetConfig("CONTEXT_MISSING_POLICY", obsidianMode, default="0"),
             "date_missing_policy": self.tryGetConfig("DATE_MISSING_POLICY", obsidianMode, default="0"),
             "default_context": self.tryGetConfig("DEFAULT_CONTEXT", obsidianMode, default="inbox"),
+            "categories_prefixes": [category["prefix"] for category in self.container.categories],
         }
-
-        categoriesConfigOption = self.config.jsonConfig.categories()
-        self.container.categories = list[dict](categoriesConfigOption)
 
         # External services
 

--- a/backend/src/containers/TelegramReportingServiceContainer.py
+++ b/backend/src/containers/TelegramReportingServiceContainer.py
@@ -196,7 +196,7 @@ class TelegramReportingServiceContainer():
         taskDiscoveryPolicies = {
             "context_missing_policy": self.tryGetConfig("CONTEXT_MISSING_POLICY", obsidianMode, default="0"),
             "date_missing_policy": self.tryGetConfig("DATE_MISSING_POLICY", obsidianMode, default="0"),
-            "default_context": self.tryGetConfig("DEFAULT_CONTEXT", obsidianMode, default="alert"),
+            "default_context": self.tryGetConfig("DEFAULT_CONTEXT", obsidianMode, default="inbox"),
         }
 
         categoriesConfigOption = self.config.jsonConfig.categories()
@@ -217,7 +217,7 @@ class TelegramReportingServiceContainer():
         self.container.userCommService = self.container.telegramUserCommService if telegramMode else self.container.shellUserCommService
 
         if obsidianMode:
-            self.container.taskJsonProvider = providers.Singleton(ObsidianVaultTaskJsonProvider, self.container.fileBroker)
+            self.container.taskJsonProvider = providers.Singleton(ObsidianVaultTaskJsonProvider, self.container.fileBroker, taskDiscoveryPolicies)
             self.container.taskProvider = providers.Singleton(ObsidianTaskProvider, self.container.taskJsonProvider, self.container.fileBroker)
         else:
             self.container.taskJsonProvider = providers.Singleton(TaskJsonProvider, self.container.fileBroker)

--- a/backend/src/containers/TelegramReportingServiceContainer.py
+++ b/backend/src/containers/TelegramReportingServiceContainer.py
@@ -73,6 +73,10 @@ class TelegramReportingServiceContainer():
                 {
                     "prefix": "outdoor",
                     "description": "Outdoor dynamic tasks"
+                },
+                {
+                    "prefix": "inbox",
+                    "description": "Inbox tasks"
                 }
             ],
         }
@@ -116,6 +120,35 @@ class TelegramReportingServiceContainer():
                 print("The directory does not exist, using current directory")
                 vaultPath = "."
             defaultConfig["OBSIDIAN_VAULT_PATH"] = vaultPath
+            # ask the user for a context missing policy
+            print("Context missing policy is the policy to use when a task does not have a context")
+            print("0 - ignore")
+            print("1 - use_default")
+            contextMissingPolicy = input("Please enter the context missing policy: (0)")
+            while contextMissingPolicy not in ["0", "1"]:
+                print("Invalid context missing policy, using 0 (ignore)")
+                contextMissingPolicy = "0"
+            defaultConfig["CONTEXT_MISSING_POLICY"] = contextMissingPolicy
+            if contextMissingPolicy == "1":
+                # ask the user for a default context
+                defaultContext = input("Please enter the default context: ")
+                # get a list of context categories prefixes
+                contextCategories = [category["prefix"] for category in defaultConfig["categories"]]
+                # check if the default context is in the list of prefixes
+                while defaultContext not in contextCategories:
+                    print(f"Invalid context, please select one of the following: {contextCategories}")
+                    defaultContext = input("Please enter the default context: ")
+
+                defaultConfig["DEFAULT_CONTEXT"] = defaultContext
+            # ask the user for a date missing policy
+            print("Date missing policy is the policy to use when a task does not have a valid date")
+            print("0 - ignore")
+            print("1 - use_current_date")
+            dateMissingPolicy = input("Please enter the date missing policy: (0)")
+            while dateMissingPolicy not in ["0", "1"]:
+                print("Invalid date missing policy, using 0 (ignore)")
+                dateMissingPolicy = "0"
+            defaultConfig["DATE_MISSING_POLICY"] = dateMissingPolicy
 
         print("Dedication time is the minimum time you are willing to compromise to completing tasks, in minutes (i.e: 60m), hours (i.e: 1h), or pomodoros (i.e: 2.4p)")
         validPomodoros = False
@@ -160,6 +193,11 @@ class TelegramReportingServiceContainer():
         vaultPath = self.tryGetConfig("OBSIDIAN_VAULT_PATH", obsidianMode, default="NULL_VAULT_PATH")
 
         dedicationTime = TimeAmount(self.tryGetConfig("DEDICATION_TIME", required=False, default="2p"))
+        taskDiscoveryPolicies = {
+            "context_missing_policy": self.tryGetConfig("CONTEXT_MISSING_POLICY", obsidianMode, default="0"),
+            "date_missing_policy": self.tryGetConfig("DATE_MISSING_POLICY", obsidianMode, default="0"),
+            "default_context": self.tryGetConfig("DEFAULT_CONTEXT", obsidianMode, default="alert"),
+        }
 
         categoriesConfigOption = self.config.jsonConfig.categories()
         self.container.categories = list[dict](categoriesConfigOption)

--- a/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
+++ b/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
@@ -133,7 +133,8 @@ class ObsidianVaultTaskJsonProvider(ITaskJsonProvider):
 
         # get task text
         # task text is everything after "- [ ]" and before any [] containing a "::"
-        textAfterCheckbox = line.split("- [ ]")[1]
+        lineMod = line + "[eol:: here]"
+        textAfterCheckbox = lineMod.split("- [ ]")[1]
         textBeforeFirstDualColon = textAfterCheckbox.split("::")[0]
         splittedByCorchetes = textBeforeFirstDualColon.split("[")
         allButLast = splittedByCorchetes[:-1]
@@ -158,12 +159,13 @@ class ObsidianVaultTaskJsonProvider(ITaskJsonProvider):
         try:
             taskDict["starts"] = self.__apply_date_policy(taskDict["starts"])
             taskDict["due"] = self.__apply_date_policy(taskDict["due"])
-            taskDict["track"] = self.__apply_track_policy(taskDict["track"])
+            taskDict["track"] = self.__apply_track_policy(taskDict.get("track", None))
             taskDict["severity"] = str(float(taskDict["severity"]))
             taskDict["total_cost"] = str(float(taskDict["remaining_cost"]) - float(taskDict["invested"]))
             taskDict["effort_invested"] = taskDict["invested"]
             taskDict["valid"] = "True"
-        except Exception:
+        except Exception as ex:
+            print(f"Error while processing task {taskDict['taskText']} in file {file} at line {lineNum}: {ex}")
             taskDict["valid"] = "False"
             pass
 

--- a/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
+++ b/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
@@ -5,12 +5,13 @@ from ..Interfaces.IFileBroker import IFileBroker, VaultRegistry
 
 class ObsidianVaultTaskJsonProvider(ITaskJsonProvider):
 
-    def __init__(self, fileBroker: IFileBroker):
+    def __init__(self, fileBroker: IFileBroker, policies: dict):
         self.__fileBroker = fileBroker
         self._lastJson = {"tasks": []}
         self._lastJsonList: list = []
         self.__lastProjectList: list = []
         self._lastMtime = 0.0
+        self.__policies = policies
 
     def getJson(self) -> dict:
         vaultFiles = self.__fileBroker.getVaultFiles(VaultRegistry.OBSIDIAN)

--- a/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
+++ b/backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py
@@ -57,7 +57,7 @@ class ObsidianVaultTaskJsonProvider(ITaskJsonProvider):
 
             if len(taskLines) == 0 and status == "open":
                 taskDict = self.__getTaskDictFromLine(
-                    "- [ ] Define next action [track::alert]",
+                    f"- [ ] Define next action [track::{self.__getFallbackPolicy()}]",
                     file[0], str(len(fileContent)),
                     fileHeader
                 )
@@ -192,3 +192,8 @@ class ObsidianVaultTaskJsonProvider(ITaskJsonProvider):
             raise ValueError("Track tag is missing and no default value is set.")
 
         return track
+
+    def __getFallbackPolicy(self) -> str:
+        if self.__policies["default_context"] in self.__policies["categories_prefixes"]:
+            return self.__policies["default_context"]
+        return self.__policies["categories_prefixes"][0] if self.__policies["categories_prefixes"] else None

--- a/backend/tests/ObsidianVaultTaskJsonProvider_test.py
+++ b/backend/tests/ObsidianVaultTaskJsonProvider_test.py
@@ -137,6 +137,38 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
         self.provider.saveJson({"tasks": []})
         # No assertions needed as the method doesn't do anything
 
+    def test_update_or_append_task_functionality(self):
+        # Test that __update_or_append_task correctly updates or appends tasks
+        # Create a task first
+        self.mock_file_broker.getVaultFiles.return_value = [("tasks.md", 100.0)]
+        self.mock_file_broker.getVaultFileLines.return_value = [
+            "---",
+            "---",
+            "- [ ] Task 1 [track::work] [severity::2]"
+        ]
+
+        result = self.provider.getJson()
+        self.assertEqual(len(result["tasks"]), 1)
+        self.assertEqual(result["tasks"][0]["taskText"], "Task 1")
+        self.assertEqual(result["tasks"][0]["severity"], "2.0")
+
+        # Now add a new task with a different line and update the existing one
+        self.mock_file_broker.getVaultFiles.return_value = [("tasks.md", 200.0)]
+        self.mock_file_broker.getVaultFileLines.return_value = [
+            "---",
+            "---",
+            "- [ ] Task 1 updated [track::work] [severity::3]",
+            "- [ ] Task 2 [track::work]"
+        ]
+
+        result = self.provider.getJson()
+        self.assertEqual(len(result["tasks"]), 2)
+
+        # Tasks should be ordered based on their order in the file
+        self.assertEqual(result["tasks"][0]["taskText"], "Task 1 updated")
+        self.assertEqual(result["tasks"][0]["severity"], "3.0")
+        self.assertEqual(result["tasks"][1]["taskText"], "Task 2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/ObsidianVaultTaskJsonProvider_test.py
+++ b/backend/tests/ObsidianVaultTaskJsonProvider_test.py
@@ -9,7 +9,12 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
 
     def setUp(self):
         self.mock_file_broker = MagicMock(spec=IFileBroker)
-        self.provider = ObsidianVaultTaskJsonProvider(self.mock_file_broker)
+        self.policies = {
+            "context_missing_policy": "0",
+            "date_missing_policy": "0",
+            "default_context": "inbox",
+        }
+        self.provider = ObsidianVaultTaskJsonProvider(self.mock_file_broker, self.policies)
 
     def test_empty_vault_returns_empty_dict(self):
         self.mock_file_broker.getVaultFiles.return_value = []

--- a/backend/tests/ObsidianVaultTaskJsonProvider_test.py
+++ b/backend/tests/ObsidianVaultTaskJsonProvider_test.py
@@ -13,6 +13,7 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
             "context_missing_policy": "0",
             "date_missing_policy": "0",
             "default_context": "inbox",
+            "categories_prefixes": ["work"],
         }
         self.provider = ObsidianVaultTaskJsonProvider(self.mock_file_broker, self.policies)
 
@@ -59,7 +60,7 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
         self.mock_file_broker.getVaultFileLines.return_value = [
             "---",
             "---",
-            "- [ ] Complete report [track::work] [due::2023-12-31] [severity::3] [remaining_cost::2] [invested::1]"
+            "- [ ] Complete report [track::work] [start::2023-12-31] [due::2023-12-31] [severity::3] [remaining_cost::2] [invested::1]"
         ]
 
         result = self.provider.getJson()
@@ -67,7 +68,7 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
         task = result["tasks"][0]
         self.assertEqual(task["taskText"], "Complete report")
         self.assertEqual(task["due"], str(TimePoint.from_string("2023-12-31").as_int()))
-        self.assertEqual(task["severity"], "3")
+        self.assertEqual(task["severity"], "3.0")
         self.assertEqual(task["remaining_cost"], "2")
         self.assertEqual(task["invested"], "1")
         self.assertEqual(task["total_cost"], "1.0")
@@ -95,7 +96,7 @@ class TestObsidianVaultTaskJsonProvider(unittest.TestCase):
 
         result = self.provider.getJson()
         task = result["tasks"][0]
-        self.assertEqual(task["severity"], "5")
+        self.assertEqual(task["severity"], "5.0")
         self.assertEqual(task["starts"], str(TimePoint.from_string("2023-01-01").as_int()))
 
     def test_update_existing_task(self):


### PR DESCRIPTION
This pull request introduces significant changes to the `TelegramReportingServiceContainer` and `ObsidianVaultTaskJsonProvider` to enhance task handling and configuration. The main updates include adding new task policies, modifying the task processing logic, and updating the corresponding unit tests.

### Enhancements to Task Handling and Configuration:

* [`backend/src/containers/TelegramReportingServiceContainer.py`](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R123-R151): Added new task policies for handling missing context and date values, and integrated these policies into the initialization and configuration processes. [[1]](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6R123-R151) [[2]](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6L163-R205) [[3]](diffhunk://#diff-790472df204be02231b9996f07a86430210d204f82f6eb119cb4b43bf39b6ef6L182-R221)

### Modifications to Task Processing Logic:

* [`backend/src/taskjsonproviders/ObsidianVaultTaskJsonProvider.py`](diffhunk://#diff-ab444d1d3c6e61f4a86992620badbab868f4617bb02024086de0af97389636f6L8-R14): Updated the constructor to accept task policies and modified task processing methods to apply these policies, including handling missing context and date values. [[1]](diffhunk://#diff-ab444d1d3c6e61f4a86992620badbab868f4617bb02024086de0af97389636f6L8-R14) [[2]](diffhunk://#diff-ab444d1d3c6e61f4a86992620badbab868f4617bb02024086de0af97389636f6L59-R60) [[3]](diffhunk://#diff-ab444d1d3c6e61f4a86992620badbab868f4617bb02024086de0af97389636f6L135-R137) [[4]](diffhunk://#diff-ab444d1d3c6e61f4a86992620badbab868f4617bb02024086de0af97389636f6L158-R201)

### Updates to Unit Tests:

* [`backend/tests/ObsidianVaultTaskJsonProvider_test.py`](diffhunk://#diff-6c09a976c0fb960a98688e74e0e765df8387c76d9518207bb8473df208559309L12-R18): Updated unit tests to reflect the new task policies and added new tests to ensure the correct application of these policies. [[1]](diffhunk://#diff-6c09a976c0fb960a98688e74e0e765df8387c76d9518207bb8473df208559309L12-R18) [[2]](diffhunk://#diff-6c09a976c0fb960a98688e74e0e765df8387c76d9518207bb8473df208559309L57-R71) [[3]](diffhunk://#diff-6c09a976c0fb960a98688e74e0e765df8387c76d9518207bb8473df208559309L93-R99) [[4]](diffhunk://#diff-6c09a976c0fb960a98688e74e0e765df8387c76d9518207bb8473df208559309R140-R171)

Closes #60