### PR TITLE
Hacer el slash opcional en un comando

### DIFF
--- a/backend/src/wrappers/ShellUserCommService.py
+++ b/backend/src/wrappers/ShellUserCommService.py
@@ -15,10 +15,16 @@ class ShellUserCommService(IUserCommService):
     async def sendMessage(self, chat_id: int, text: str, parse_mode: str = None) -> None:
         print(f"[bot -> {chat_id}]: {text}")
 
+    def __preprocessMessageText(self, text: str) -> str:
+        if not text.startswith("/"):
+            text = "/" + text
+
+        return text
+
     async def getMessageUpdates(self) -> tuple[int, str]:
         text = input(f"[User({self.chatId})]: ")
         self.offset += 1
-        return (self.chatId, text)
+        return (self.chatId, self.__preprocessMessageText(text))
 
     async def sendFile(self, chat_id: int, data: bytearray) -> None:
         print(f"[bot -> {chat_id}]: File sent")

--- a/backend/src/wrappers/TelegramBotUserCommService.py
+++ b/backend/src/wrappers/TelegramBotUserCommService.py
@@ -24,6 +24,9 @@ class TelegramBotUserCommService(IUserCommService):
         pass
 
     def __preprocessMessageText(self, text: str) -> str:
+        if not text.startswith("/"):
+            text = "/" + text
+
         parts = text.split(' ')
 
         if parts and "__" in parts[0]:

--- a/backend/tests/ShellUserCommService_test.py
+++ b/backend/tests/ShellUserCommService_test.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+from src.wrappers.ShellUserCommService import ShellUserCommService
+
+
+class TestShellUserCommService(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.chat_id = 12345
+        self.service = ShellUserCommService(self.chat_id)
+
+    async def test_initialize(self):
+        with patch("builtins.print") as mock_print:
+            await self.service.initialize()
+            mock_print.assert_called_once_with("ShellUserBotService initialized")
+
+    async def test_shutdown(self):
+        with patch("builtins.print") as mock_print:
+            await self.service.shutdown()
+            mock_print.assert_called_once_with("ShellUserBotService shutdown")
+
+    async def test_sendMessage(self):
+        with patch("builtins.print") as mock_print:
+            await self.service.sendMessage(self.chat_id, "Test message")
+            mock_print.assert_called_once_with(f"[bot -> {self.chat_id}]: Test message")
+
+    async def test_getMessageUpdates(self):
+        with patch("builtins.input", return_value="test message"):
+            result = await self.service.getMessageUpdates()
+            assert result == (self.chat_id, "/test message")
+            assert self.service.offset == 1
+
+    async def test_sendFile(self):
+        test_data = bytearray(b"Test file content")
+        with patch("builtins.print") as mock_print:
+            await self.service.sendFile(self.chat_id, test_data)
+            mock_print.assert_any_call(f"[bot -> {self.chat_id}]: File sent")
+            mock_print.assert_any_call(f"File content: {test_data[:128]}... ({len(test_data)} bytes)")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/TelegramBotUserCommService_test.py
+++ b/backend/tests/TelegramBotUserCommService_test.py
@@ -27,37 +27,49 @@ class TestTelegramBotUserCommService(unittest.TestCase):
         # Test with double underscore in the first word
         input_text = "command__name parameter1 parameter2"
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == "command name parameter1 parameter2"
+        assert processed_text == "/command name parameter1 parameter2"
 
     def test_preprocess_message_text_without_double_underscore(self):
         # Test with no double underscore
         input_text = "command parameter1 parameter2"
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == "command parameter1 parameter2"
+        assert processed_text == "/command parameter1 parameter2"
 
     def test_preprocess_message_text_with_double_underscore_not_in_first_word(self):
         # Test with double underscore in a word that's not first
         input_text = "command param__eter1 parameter2"
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == "command param__eter1 parameter2"
+        assert processed_text == "/command param__eter1 parameter2"
 
     def test_preprocess_message_text_with_multiple_double_underscores_in_first_word(self):
         # Test with multiple double underscores in first word
         input_text = "comm__and__name parameter1 parameter2"
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == "comm and name parameter1 parameter2"
+        assert processed_text == "/comm and name parameter1 parameter2"
 
     def test_preprocess_message_text_single_word(self):
         # Test with just one word containing double underscore
         input_text = "command__name"
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == "command name"
+        assert processed_text == "/command name"
 
     def test_preprocess_message_text_empty_string(self):
         # Test with empty string
         input_text = ""
         processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
-        assert processed_text == ""
+        assert processed_text == "/"
+
+    def test_preprocess_message_text_no_leading_slash(self):
+        # Test with no leading slash in the input text
+        input_text = "command"
+        processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
+        assert processed_text == "/command"
+
+    def test_preprocess_message_text_with_leading_slash(self):
+        # Test with leading slash in the input text
+        input_text = "/command"
+        processed_text = self.service._TelegramBotUserCommService__preprocessMessageText(input_text)
+        assert processed_text == "/command"
 
 
 class TestTelegramBotUserCommServiceAsync(unittest.IsolatedAsyncioTestCase):
@@ -97,7 +109,7 @@ class TestTelegramBotUserCommServiceAsync(unittest.IsolatedAsyncioTestCase):
         self.telegram_bot.getUpdates = AsyncMock(return_value=[mock_update])
 
         result = await self.service.getMessageUpdates()
-        assert result == (67890, "hello world")
+        assert result == (67890, "/hello world")
         assert self.service.offset == 12346  # update_id + 1
 
     async def test_getMessageUpdates_with_document(self):


### PR DESCRIPTION
This pull request introduces a preprocessing step to ensure all user-provided messages start with a leading slash (`/`) and updates the corresponding tests to validate this behavior. It also adds a comprehensive test suite for the `ShellUserCommService` class.

### Message Preprocessing Enhancements:
* Added a `__preprocessMessageText` method in `ShellUserCommService` to prepend a leading slash (`/`) to messages that do not start with one. Integrated this method into the `getMessageUpdates` function to ensure consistent message formatting. (`backend/src/wrappers/ShellUserCommService.py`, [backend/src/wrappers/ShellUserCommService.pyR18-R27](diffhunk://#diff-7709133f9879548e543d89013b087bf84ebc37e55b8ad04986e75933282fb6ceR18-R27))
* Updated the `__preprocessMessageText` method in `TelegramBotUserCommService` to include the same logic for adding a leading slash if missing. (`backend/src/wrappers/TelegramBotUserCommService.py`, [backend/src/wrappers/TelegramBotUserCommService.pyR27-R29](diffhunk://#diff-0bf7cb0e59c9d343fb38531c1e50f893b46be8d736637f184c661838dd96cd2cR27-R29))

### Test Updates and Additions:
* Added a new test suite for `ShellUserCommService` using `unittest.IsolatedAsyncioTestCase`, covering initialization, shutdown, message sending, file sending, and message updates with preprocessing validation. (`backend/tests/ShellUserCommService_test.py`, [backend/tests/ShellUserCommService_test.pyR1-R42](diffhunk://#diff-d4909cfa1a3a4755d9d93bfd8e65641f80c7fbd82c00da0b76fbdd1d0816fb95R1-R42))
* Updated existing tests for `TelegramBotUserCommService` to validate the addition of a leading slash in various scenarios, including empty input, single words, and messages with or without an existing leading slash. (`backend/tests/TelegramBotUserCommService_test.py`, [backend/tests/TelegramBotUserCommService_test.pyL30-R72](diffhunk://#diff-db37630188986d0a5bffdb520f56c0db75dc2e2a269dae32f3eb00fb3c403f18L30-R72))
* Modified the `test_getMessageUpdates_with_text_message` test to validate that the returned message includes the leading slash after preprocessing. (`backend/tests/TelegramBotUserCommService_test.py`, [backend/tests/TelegramBotUserCommService_test.pyL100-R112](diffhunk://#diff-db37630188986d0a5bffdb520f56c0db75dc2e2a269dae32f3eb00fb3c403f18L100-R112))

Closes #74 