### PR TITLE
Update default task context to "inbox"

### DIFF
--- a/backend/src/taskproviders/ObsidianTaskProvider.py
+++ b/backend/src/taskproviders/ObsidianTaskProvider.py
@@ -122,7 +122,7 @@ class ObsidianTaskProvider(ITaskProvider):
         status = " "
         calm = "False"
 
-        task = ObsidianTaskModel(description, "workstation", starts, due, 1, severity, invested, status, "", -1, calm)
+        task = ObsidianTaskModel(description, "inbox", starts, due, 1, severity, invested, status, "", -1, calm)
         return task
 
     def getTaskMetadata(self, task: ITaskModel) -> str:

--- a/backend/src/taskproviders/TaskProvider.py
+++ b/backend/src/taskproviders/TaskProvider.py
@@ -130,7 +130,7 @@ class TaskProvider(ITaskProvider):
 
         default_task = dict(
             description=description,
-            context="workstation",
+            context="inbox",
             start=starts,
             due=due,
             severity=severity,

--- a/backend/tests/TaskProvider_test.py
+++ b/backend/tests/TaskProvider_test.py
@@ -137,14 +137,14 @@ class TestTaskProvider(unittest.TestCase):
         task = self.task_provider.createDefaultTask("New Task")
         # Check task properties
         self.assertEqual(task.getDescription(), "New Task")
-        self.assertEqual(task.getContext(), "workstation")
+        self.assertEqual(task.getContext(), "inbox")
         self.assertEqual(task.getSeverity(), 1.0)
         self.assertEqual(task.getStatus(), " ")
         self.assertFalse(task.getCalm())
 
         # Ensure task was added to the task list
         self.assertIn(
-            {"description": "New Task", "context": "workstation", "status": " ", "calm": "False"},
+            {"description": "New Task", "context": "inbox", "status": " ", "calm": "False"},
             [
                 {k: t[k] for k in ["description", "context", "status", "calm"]}
                 for t in self.task_provider.dict_task_list["tasks"]


### PR DESCRIPTION
Change the default context for tasks from "workstation" to "inbox" to align with updated workflow preferences. Adjust related task creation methods and tests accordingly.