### PR TITLE
Add unique task identifier method and update task descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ RUN_IN_VENV = . .venv/bin/activate &&
 
 test: .venv
 	$(RUN_IN_VENV) ./tools/bash/local-quality-checks.sh
+
+run: .venv
+	$(RUN_IN_VENV) python3 backend/backend.py

--- a/backend/src/Interfaces/ITaskModel.py
+++ b/backend/src/Interfaces/ITaskModel.py
@@ -107,6 +107,10 @@ class ITaskModel(ABC):
         pass
 
     @abstractmethod
+    def getTaskUID(self) -> str:
+        pass
+
+    @abstractmethod
     def calculateRemainingTime(self) -> TimeAmount:
         pass
 

--- a/backend/src/TelegramTaskListManager.py
+++ b/backend/src/TelegramTaskListManager.py
@@ -221,8 +221,7 @@ class TelegramTaskListManager(ITaskListManager):
             if len(self.__heuristicList) > 0 and isinstance(self.__selectedHeuristic, tuple):
                 heuristic_value = self.__selectedHeuristic[1].evaluate(task)
             
-            # Use hash of description as ID if getId is not available
-            task_id = getattr(task, "getId", lambda: str(i + 1))()
+            task_id = task.getTaskUID()
             
             tasks.append(TaskEntry(
                 id=task_id,
@@ -336,9 +335,8 @@ class TelegramTaskListManager(ITaskListManager):
         
         # Format the active urgent tasks
         active_urgent_tasks: list[TaskEntry] = []
-        for i, task in enumerate(current_urgents_by_categories):
-            # Use task description hash as ID if getId is not available
-            task_id = getattr(task, "getId", lambda: f"active_{i}")()
+        for _, task in enumerate(current_urgents_by_categories):
+            task_id = task.getTaskUID()
             
             active_urgent_tasks.append(
                 TaskEntry(
@@ -359,9 +357,8 @@ class TelegramTaskListManager(ITaskListManager):
         planned_urgent_tasks: list[TaskEntry] = []
         planned_tasks_by_date: dict[str, list[TaskEntry]] = {}
         
-        for i, task in enumerate(urgent_tasks_by_start):
-            # Use task description hash as ID if getId is not available
-            task_id = getattr(task, "getId", lambda: f"planned_{i}")()
+        for _, task in enumerate(urgent_tasks_by_start):
+            task_id = task.getTaskUID()
             
             task_data = TaskEntry(
                 id=task_id,
@@ -385,9 +382,8 @@ class TelegramTaskListManager(ITaskListManager):
             
         # Format the other tasks
         other_tasks_formatted: list[TaskEntry] = []
-        for i, task in enumerate(other_tasks):
-            # Use task description hash as ID if getId is not available
-            task_id = getattr(task, "getId", lambda: f"other_{i}")()
+        for _, task in enumerate(other_tasks):
+            task_id = task.getTaskUID()
             
             other_tasks_formatted.append(
                 TaskEntry(

--- a/backend/src/TelegramTaskListManager.py
+++ b/backend/src/TelegramTaskListManager.py
@@ -114,7 +114,8 @@ class TelegramTaskListManager(ITaskListManager):
                     taskListSearched.append(task)
                     break
 
-        return TelegramTaskListManager(taskListSearched, [], [], self.__filterList, self.__statistics_service, self.__tasksPerPage)
+        deactivatedFilters = [(name, filt, True) for name, filt, _ in self.__filterList]
+        return TelegramTaskListManager(taskListSearched, [], [], deactivatedFilters, self.__statistics_service, self.__tasksPerPage)
 
     def render_filter_summary(self, taskListString: str) -> str:
         isOnlyFirstFilterActive = len([f for f in self.__filterList if f[2]]) == 1 and self.__filterList[0][2]

--- a/backend/src/taskmodels/ObsidianTaskModel.py
+++ b/backend/src/taskmodels/ObsidianTaskModel.py
@@ -1,3 +1,4 @@
+import hashlib
 from ..Interfaces.ITaskModel import ITaskModel
 from .TaskModel import TaskModel
 
@@ -38,6 +39,10 @@ class ObsidianTaskModel(TaskModel):
 
     def __eq__(self, other: ITaskModel):  # type: ignore
         return self.getEventRaised() == other.getEventRaised() and self.getEventWaited() == other.getEventWaited() and self.getDescription() == other.getDescription() and self.getContext() == other.getContext() and self.getStart() == other.getStart() and self.getDue() == other.getDue() and self.getSeverity() == other.getSeverity() and self.getTotalCost().as_pomodoros() == other.getTotalCost().as_pomodoros() and self.getInvestedEffort().as_pomodoros() == other.getInvestedEffort().as_pomodoros() and self.getStatus() == other.getStatus() and self.getFile() == other.getFile() and self.getLine() == other.getLine() and self.getCalm() == other.getCalm()  # type: ignore
+
+    def getTaskUID(self) -> str:
+        hash_input = f"{self._description}{self._file}{self._line}"
+        return hashlib.md5(hash_input.encode()).hexdigest()
 
     # Class methods
     def getFile(self) -> str:

--- a/backend/src/taskmodels/ObsidianTaskModel.py
+++ b/backend/src/taskmodels/ObsidianTaskModel.py
@@ -27,7 +27,7 @@ class ObsidianTaskModel(TaskModel):
         Returns:
             str: The enriched task description.
         """
-        return f"({self._context}) {self._description} @ '{self.getProject()}'"
+        return f"({self._context}) {self._description} @ '{self.getProject()}' [{self.getTaskUID()[0:5]}]"
 
     def getProject(self) -> str:
         """

--- a/backend/src/taskmodels/TaskModel.py
+++ b/backend/src/taskmodels/TaskModel.py
@@ -113,6 +113,9 @@ class TaskModel(ITaskModel):
         d = max(0, d)
         d = ceil(d)
         return TimeAmount(f"{d}d")
+    
+    def getTaskUID(self) -> str:
+        return f"{self._index}"
 
     def __eq__(self, other: ITaskModel):  # type: ignore
         return self._index == other._index  # type: ignore

--- a/backend/src/wrappers/ShellUserCommService.py
+++ b/backend/src/wrappers/ShellUserCommService.py
@@ -5,10 +5,20 @@ from src.wrappers.interfaces.IUserCommService import IUserCommService
 
 
 class ShellUserCommService(IUserCommService):
-    def __init__(self, chatId: int, agent: IAgent) -> None:
+    RESET = "\033[0m"
+    BOLD = "\033[1m"
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    MAGENTA = "\033[95m"
+    CYAN = "\033[96m"
+
+    def __init__(self, chatId: int, agent: IAgent, useColors: bool = True) -> None:
         self.offset = 0
         self.chatId = int(chatId)
         self.agent = agent
+        self.__useColors = useColors
 
         self.__renders = {
             RenderMode.TASK_LIST: self.__renderTaskList,
@@ -24,7 +34,7 @@ class ShellUserCommService(IUserCommService):
         }
 
     def __renderFilterList(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Filter List Render Mode")
+        self.__botPrint(self.__bold("(Info) Filter List Render Mode"))
         filter_list = message.content.filterListDict
         if not isinstance(filter_list, list) or not filter_list:
             self.__botPrint("No filters available")
@@ -34,7 +44,8 @@ class ShellUserCommService(IUserCommService):
             name = filter_info.name
             description = filter_info.description
             enabled = filter_info.enabled
-            self.__botPrint(f" - (/filter_{i + 1}) {name}: {description} [{'ENABLED' if enabled else 'DISABLED'}]")
+            status = self.__green("ENABLED") if enabled else self.__red("DISABLED")
+            self.__botPrint(f" - (/filter_{i + 1}) {name}: {description} [{status}]")
 
     async def initialize(self) -> None:
         print("ShellUserBotService initialized")
@@ -85,7 +96,7 @@ class ShellUserCommService(IUserCommService):
         return self.agent
 
     def __renderTaskList(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Task List Render Mode")
+        self.__botPrint(self.__bold("(Info) Task List Render Mode"))
         
         content = message.content.taskListContent
         if not isinstance(content, TaskListContent):
@@ -97,20 +108,20 @@ class ShellUserCommService(IUserCommService):
         tasks = content.tasks
 
         # Print the algorithm details as a header
-        print(f"Algorithm: {algorithm_name}\nDescription: {algorithm_desc}\nSort Heuristic: {sort_heuristic}\n")
-        print("Tasks:")
+        print(f"{self.__cyan('Algorithm:')} {algorithm_name}\n{self.__cyan('Description:')} {algorithm_desc}\n{self.__cyan('Sort Heuristic:')} {sort_heuristic}\n")
+        print(self.__bold("Tasks:"))
         for task in tasks:
             task_id = task.id
             task_desc = task.description
             task_context = task.context
-            print(f"  - Task ID: {task_id}, Description: {task_desc}, Context: {task_context}")
+            print(f"  - {self.__blue('Task ID:')} {task_id}, {self.__blue('Description:')} {task_desc}, {self.__blue('Context:')} {task_context}")
 
     def __renderRawText(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Raw Text Render Mode")
+        self.__botPrint(self.__bold("(Info) Raw Text Render Mode"))
         self.__botPrint(str(message.content.text))
 
     def __notifyListUpdated(self, message: IMessage) -> None:
-        self.__botPrint("(Info) List Updated Render Mode")
+        self.__botPrint(self.__bold("(Info) List Updated Render Mode"))
 
         algorithm_desc = message.content.text
         most_priority_task = message.content.task
@@ -120,10 +131,10 @@ class ShellUserCommService(IUserCommService):
             self.__botPrint("No tasks available")
             return
 
-        self.__botPrint(f"Most priority task: {most_priority_task.getDescription()} (ID: /task_1, Context: {most_priority_task.getContext()})")
+        self.__botPrint(f"Most priority task: {self.__green(most_priority_task.getDescription())} (ID: /task_1, Context: {most_priority_task.getContext()})")
 
     def __renderHeuristicList(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Heuristic List Render Mode")
+        self.__botPrint(self.__bold("(Info) Heuristic List Render Mode"))
         heuristic_list = message.content.anonObjectList
 
         if not isinstance(heuristic_list, list) or not heuristic_list:
@@ -136,7 +147,7 @@ class ShellUserCommService(IUserCommService):
             self.__botPrint(f" - (/heuristic_{i + 1}) {heuristic['name']}: {heuristic['description']}")
 
     def __renderAlgorithmList(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Algorithm List Render Mode")
+        self.__botPrint(self.__bold("(Info) Algorithm List Render Mode"))
         algorithm_list = message.content.anonObjectList
 
         if not isinstance(algorithm_list, list) or not algorithm_list:
@@ -148,11 +159,41 @@ class ShellUserCommService(IUserCommService):
             assert isinstance(algorithm, dict)
             self.__botPrint(f" - (/algorithm_{i + 1}) {algorithm['name']}: {algorithm['description']}")
 
-    def __botPrint(self, text: str) -> None:
-        print(f"[bot -> {self.chatId}]: {text}")
+    def __botPrint(self, text: str, color: str = "") -> None:
+        prefix = f"[bot -> {self.chatId}]: "
+        if self.__useColors and color:
+            print(f"{prefix}{color}{text}{self.RESET}")
+        else:
+            print(f"{prefix}{text}")
+
+    def __colorize(self, text: str, color: str) -> str:
+        if self.__useColors:
+            return f"{color}{text}{self.RESET}"
+        return text
+
+    def __bold(self, text: str) -> str:
+        return self.__colorize(text, self.BOLD)
+
+    def __red(self, text: str) -> str:
+        return self.__colorize(text, self.RED)
+
+    def __green(self, text: str) -> str:
+        return self.__colorize(text, self.GREEN)
+
+    def __yellow(self, text: str) -> str:
+        return self.__colorize(text, self.YELLOW)
+
+    def __blue(self, text: str) -> str:
+        return self.__colorize(text, self.BLUE)
+
+    def __magenta(self, text: str) -> str:
+        return self.__colorize(text, self.MAGENTA)
+
+    def __cyan(self, text: str) -> str:
+        return self.__colorize(text, self.CYAN)
 
     def __renderTaskStats(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Task Stats Render Mode")
+        self.__botPrint(self.__bold("(Info) Task Stats Render Mode"))
         
         # Import time management classes
         from src.wrappers.TimeManagement import TimePoint, TimeAmount
@@ -171,7 +212,7 @@ class ShellUserCommService(IUserCommService):
         work_done_log = stats.workDoneLog
         
         # Format and display workload statistics
-        self.__botPrint("Work done in the last 7 days:")
+        self.__botPrint(self.__cyan("Work done in the last 7 days:"))
         self.__botPrint("|    Date    | Work  Done |")
         self.__botPrint("|------------|------------|")
         
@@ -194,14 +235,14 @@ class ShellUserCommService(IUserCommService):
         self.__botPrint("|------------|------------|")
         
         # Display workload statistics
-        self.__botPrint("\nWorkload statistics:")
+        self.__botPrint(self.__bold("\nWorkload statistics:"))
         self.__botPrint(f"current workload: {workload} per day")
-        self.__botPrint(f"max Offender: '{offender}' with {offender_max} per day")
+        self.__botPrint(f"max Offender: '{self.__red(offender)}' with {offender_max} per day")
         self.__botPrint(f"total remaining effort: {remaining_effort}")
         self.__botPrint(f"max {heuristic_name}: {heuristic_value}")
         
         # Display work done log
-        self.__botPrint("\nWork done log:")
+        self.__botPrint(self.__bold("\nWork done log:"))
         for entry in work_done_log:
             task = entry.task
             work_units = entry.work_units
@@ -213,7 +254,7 @@ class ShellUserCommService(IUserCommService):
         self.__botPrint("\n/list - return back to the task list")
         
     def __renderTaskAgenda(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Task Agenda Render Mode")
+        self.__botPrint(self.__bold("(Info) Task Agenda Render Mode"))
         
         # Get content from message
         agenda = message.content.agendaContent
@@ -231,14 +272,14 @@ class ShellUserCommService(IUserCommService):
         
         # Display active urgent tasks
         if active_urgent_tasks:
-            self.__botPrint("# Active Urgent tasks:")
+            self.__botPrint(self.__red("# Active Urgent tasks:"))
             for task in active_urgent_tasks:
                 self.__botPrint(f"- {task.description} (Context: {task.context})")
             self.__botPrint("")
         
         # Display planned urgent tasks
         if planned_urgent_tasks:
-            self.__botPrint("# Planned Urgent tasks:")
+            self.__botPrint(self.__yellow("# Planned Urgent tasks:"))
             for dateStr, tasks in planned_tasks_by_date.items():
                 self.__botPrint(f"## {dateStr}")
                 for task in tasks:
@@ -247,7 +288,7 @@ class ShellUserCommService(IUserCommService):
         
         # Display other tasks
         if other_tasks:
-            self.__botPrint("# Other tasks:")
+            self.__botPrint(self.__cyan("# Other tasks:"))
             for task in other_tasks:
                 self.__botPrint(f"- {task.description} (Context: {task.context})")
             self.__botPrint("")
@@ -255,7 +296,7 @@ class ShellUserCommService(IUserCommService):
         self.__botPrint("/list - return back to the task list")
         
     def __renderTaskInformation(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Task Information Render Mode")
+        self.__botPrint(self.__bold("(Info) Task Information Render Mode"))
         
         # Extract task information from the message
         taskinfo = message.content.taskInformation
@@ -275,7 +316,7 @@ class ShellUserCommService(IUserCommService):
         # task_calm = message.content.get('calm', False)
         
         # Format the basic task information
-        self.__botPrint(f"Task: {task_description}")
+        self.__botPrint(f"Task: {self.__green(task_description)}")
         self.__botPrint(f"Context: {task_context}")
         self.__botPrint(f"Start Date: {task_start_date}")
         self.__botPrint(f"Due Date: {task_due_date}")
@@ -286,23 +327,23 @@ class ShellUserCommService(IUserCommService):
         # Include extended information if available
         extended_task_data = taskinfo.extended
         if isinstance(extended_task_data, ExtendedTaskInformation):
-            self.__botPrint("\nHeuristic Values:")
+            self.__botPrint(self.__bold("\nHeuristic Values:"))
             for heuristic in extended_task_data.heuristics:
                 self.__botPrint(f"- {heuristic.name}: {heuristic.comment}")
         
-            self.__botPrint("\nMetadata:")
+            self.__botPrint(self.__bold("\nMetadata:"))
             self.__botPrint(extended_task_data.metadata)
         
         # Add command options
-        self.__botPrint("\n/list - Return to list")
-        self.__botPrint("/done - Mark task as done")
-        self.__botPrint("/set [param] [value] - Set task parameter")
-        self.__botPrint("/work [work_units] - Invest work units in the task")
-        self.__botPrint("/snooze - Snooze the task for 5 minutes")
-        self.__botPrint("/info - Show extended information")
+        self.__botPrint(self.__cyan("\n/list - Return to list"))
+        self.__botPrint(self.__cyan("/done - Mark task as done"))
+        self.__botPrint(self.__cyan("/set [param] [value] - Set task parameter"))
+        self.__botPrint(self.__cyan("/work [work_units] - Invest work units in the task"))
+        self.__botPrint(self.__cyan("/snooze - Snooze the task for 5 minutes"))
+        self.__botPrint(self.__cyan("/info - Show extended information"))
 
     def __renderEvents(self, message: IMessage) -> None:
-        self.__botPrint("(Info) Events Render Mode")
+        self.__botPrint(self.__bold("(Info) Events Render Mode"))
         
         # Extract events content from the message
         events = message.content.eventsContent
@@ -317,16 +358,16 @@ class ShellUserCommService(IUserCommService):
         event_statistics = events.event_statistics
 
         # Display overall statistics
-        self.__botPrint("Event Statistics Summary:")
+        self.__botPrint(self.__cyan("Event Statistics Summary:"))
         self.__botPrint(f"Total Events: {total_events}")
         self.__botPrint(f"Tasks Raising Events: {total_raising_tasks}")
         self.__botPrint(f"Tasks Waiting for Events: {total_waiting_tasks}")
-        self.__botPrint(f"Orphaned Events: {orphaned_events_count}")
+        self.__botPrint(f"Orphaned Events: {self.__red(str(orphaned_events_count))}")
         self.__botPrint("")
 
         # Display individual event statistics
         if event_statistics:
-            self.__botPrint("Individual Event Statistics:")
+            self.__botPrint(self.__bold("Individual Event Statistics:"))
             self.__botPrint("| Event Name | Raising | Waiting | Status |")
             self.__botPrint("|------------|---------|---------|--------|")
             
@@ -334,18 +375,18 @@ class ShellUserCommService(IUserCommService):
                 event_name = event_stat.event_name
                 tasks_raising = event_stat.tasks_raising
                 tasks_waiting = event_stat.tasks_waiting
-                status = "ORPHANED" if event_stat.is_orphaned else "OK"
+                status = self.__red("ORPHANED") if event_stat.is_orphaned else self.__green("OK")
                 if event_stat.is_orphaned:
                     if event_stat.orphan_type == "raised_only":
-                        status += " (raised only)"
+                        status += self.__red(" (raised only)")
                     elif event_stat.orphan_type == "waited_only":
-                        status += " (waited only)"
+                        status += self.__red(" (waited only)")
                 
                 self.__botPrint(f"| {event_name:10} | {tasks_raising:7} | {tasks_waiting:7} | {status:6} |")
         else:
             self.__botPrint("No events found in the current task list.")
 
-        self.__botPrint("\n/list - return back to the task list")
+        self.__botPrint(self.__cyan("\n/list - return back to the task list"))
 
     async def sendMessage(self, message: IMessage) -> None:
         if message.type != "OutboundMessage":

--- a/backend/tests/ObsidianTaskModel_test.py
+++ b/backend/tests/ObsidianTaskModel_test.py
@@ -27,17 +27,20 @@ class TestObsidianTaskModel(unittest.TestCase):
         )
 
     def test_getDescription(self):
-        expected_description = "(Test Context) Test Task @ 'test_file:10'"
+        expected_uid = self.task.getTaskUID()[0:5]
+        expected_description = f"(Test Context) Test Task @ 'test_file:10' [{expected_uid}]"
         self.assertEqual(self.task.getDescription(), expected_description)
 
     def test_getDescription_withLinuxSubdirectory(self):
         self.task.setFile("subdirectory/test_file.md")
-        expected_description = "(Test Context) Test Task @ 'test_file:10'"
+        expected_uid = self.task.getTaskUID()[0:5]
+        expected_description = f"(Test Context) Test Task @ 'test_file:10' [{expected_uid}]"
         self.assertEqual(self.task.getDescription(), expected_description)
 
     def test_getDescription_withWindowsSubdirectory(self):
         self.task.setFile("subdirectory\\test_file.md")
-        expected_description = "(Test Context) Test Task @ 'test_file:10'"
+        expected_uid = self.task.getTaskUID()[0:5]
+        expected_description = f"(Test Context) Test Task @ 'test_file:10' [{expected_uid}]"
         self.assertEqual(self.task.getDescription(), expected_description)
 
     def test_getFile(self):

--- a/backend/tests/ObsidianTaskProvider_test.py
+++ b/backend/tests/ObsidianTaskProvider_test.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import unittest
 from unittest.mock import MagicMock
@@ -151,8 +152,11 @@ class TestObsidianTaskProvider(unittest.TestCase):
             _file = task["file"]
             _line = task["line"]
 
+            hash_input = f"{text}{_file}{_line}"
+            task_uid = hashlib.md5(hash_input.encode()).hexdigest()[0:5]
+
             retval["tasks"].append({
-                "description": f"({task['track']}) {text} @ '{_file.split(slash).pop().split(dot)[0]}:{_line}'",
+                "description": f"({task['track']}) {text} @ '{_file.split(slash).pop().split(dot)[0]}:{_line}' [{task_uid}]",
                 "context": task["track"],
                 "start": str(int(task["starts"])),
                 "due": str(int(task["due"])),

--- a/backend/tests/ShellUserCommService_test.py
+++ b/backend/tests/ShellUserCommService_test.py
@@ -9,7 +9,7 @@ class TestShellUserCommService(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.chat_id = 12345
         self.agent = Mock(spec=IAgent)
-        self.service = ShellUserCommService(self.chat_id, self.agent)
+        self.service = ShellUserCommService(self.chat_id, self.agent, useColors=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request introduces a unique identifier (UID) system for tasks, ensuring each task can be referenced consistently across the codebase. The UID is now used in various places where task identification is required, replacing previous ad-hoc or index-based approaches. Additionally, task descriptions now include a short version of the UID for better traceability, and related tests and utilities have been updated accordingly.

**Task identification and UID integration:**

* Added the `getTaskUID` abstract method to the `ITaskModel` interface, requiring all task models to provide a unique identifier for each task.
* Implemented `getTaskUID` in `TaskModel` (using the index) and `ObsidianTaskModel` (using an MD5 hash of description, file, and line). [[1]](diffhunk://#diff-943adb15abf7bf3f005068536dbe67b19de46cf30d3190914c1e054839766914R117-R119) [[2]](diffhunk://#diff-552010e7eafaeed9389497e0dc9182c17f1aca82896cc6137d390475c307dd09R43-R46)

**Refactoring to use UID for task identification:**

* Updated `TelegramTaskListManager` to use `getTaskUID()` instead of previous fallback mechanisms for generating task IDs in `get_task_list_content` and `get_day_agenda_content`. [[1]](diffhunk://#diff-f3e984f9632f63e85613c82e34cae0c942db28ec82dfe3429274216842848528L224-R225) [[2]](diffhunk://#diff-f3e984f9632f63e85613c82e34cae0c942db28ec82dfe3429274216842848528L339-R340) [[3]](diffhunk://#diff-f3e984f9632f63e85613c82e34cae0c942db28ec82dfe3429274216842848528L362-R362) [[4]](diffhunk://#diff-f3e984f9632f63e85613c82e34cae0c942db28ec82dfe3429274216842848528L388-R387)

**Task description improvements:**

* Modified `ObsidianTaskModel.getDescription()` to append the first five characters of the task UID to the description, improving traceability.

**Testing and utility updates:**

* Updated tests in `ObsidianTaskModel_test.py` and `ObsidianTaskProvider_test.py` to expect and validate the new UID-included descriptions. [[1]](diffhunk://#diff-abe0721a8a56fee8905fb393455e8e95fa1629bbd679c05ef9bf4a62612b4fd6L30-R43) [[2]](diffhunk://#diff-fe3a666ac267334f7a3a786ce27578d0da5bcbbde782c3008ade67fbc3261ed0R155-R159)
* Added necessary imports for `hashlib` in affected files. [[1]](diffhunk://#diff-552010e7eafaeed9389497e0dc9182c17f1aca82896cc6137d390475c307dd09R1) [[2]](diffhunk://#diff-fe3a666ac267334f7a3a786ce27578d0da5bcbbde782c3008ade67fbc3261ed0R1)

**Other adjustments:**

* Adjusted the filter handling in `search_tasks` to ensure filters are deactivated for the new task list after a search.

Closes #116